### PR TITLE
Add `cache.function` method

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -27,13 +27,13 @@ expectType<(n: string) => Promise<number>>(cache.function(
 
 expectType<(n: string) => Promise<number>>(cache.function(
 	(n: string) => Number(n)
-, {
-	expiration: 20
-}));
+	, {
+		expiration: 20
+	}));
 
 expectType<(date: Date) => Promise<string>>(cache.function(
 	(date: Date) => String(date.getHours())
-, {
-	cacheKey: ([date]) => date.toLocaleString()
-}));
+	, {
+		cacheKey: ([date]) => date.toLocaleString()
+	}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -29,6 +29,18 @@ expectType<(n: string) => Promise<number>>(
 	cache.function(async (n: string) => Number(n))
 );
 
+function identity(x: string): string;
+function identity(x: number): number;
+function identity(x: number | string): number | string {
+	return x;
+}
+
+// TODO: Overloads are failing
+expectType<Promise<number>>(cache.function(identity)(1));
+/// expectType<Promise<string>>(cache.function(identity)('1'));
+expectNotAssignable<Promise<string>>(cache.function(identity)(1));
+/// expectNotAssignable<Promise<number>>(cache.function(identity)('1'));
+
 expectType<(n: string) => Promise<number>>(
 	cache.function((n: string) => Number(n), {
 		expiration: 20

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -27,13 +27,13 @@ expectType<(n: string) => Promise<number>>(cache.function(
 
 expectType<(n: string) => Promise<number>>(cache.function(
 	(n: string) => Number(n)
-	, {
-		expiration: 20
-	}));
+, {
+	expiration: 20
+}));
 
-expectType<(date: Date) => Promise<string | undefined>>(cache.function(
-	(date: Date) => date.getHours() > 6 ? String(date) : undefined
-	, {
-		cacheKey: ([date]) => date.toLocaleString()
-	}));
+expectType<(date: Date) => Promise<string>>(cache.function(
+	(date: Date) => String(date.getHours())
+, {
+	cacheKey: ([date]) => date.toLocaleString()
+}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,3 +16,24 @@ expectType<Promise<void>>(cache.set('key', true));
 expectType<Promise<void>>(cache.set('key', [true, 'string']));
 expectType<Promise<void>>(cache.set('key', {wow: [true, 'string']}));
 expectType<Promise<void>>(cache.set('key', 1, 1));
+
+const cachedPower = cache.function((n: number) => n ** 1000);
+expectType<(n: number) => Promise<number>>(cachedPower);
+expectType<number>(await cachedPower(1));
+
+expectType<(n: string) => Promise<number>>(cache.function(
+	(n: string) => Number(n)
+));
+
+expectType<(n: string) => Promise<number>>(cache.function(
+	(n: string) => Number(n)
+	, {
+		expiration: 20
+	}));
+
+expectType<(date: Date) => Promise<string | undefined>>(cache.function(
+	(date: Date) => date.getHours() > 6 ? String(date) : undefined
+	, {
+		cacheKey: ([date]) => date.toLocaleString()
+	}));
+

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType, expectNotAssignable} from 'tsd';
+import {expectType, expectNotAssignable, expectAssignable} from 'tsd';
 import cache from '.';
 
 type Primitive = boolean | number | string;
@@ -11,11 +11,11 @@ expectType<Promise<Value | undefined>>(cache.get('key'));
 expectType<Promise<string | undefined>>(cache.get<string>('key'));
 expectNotAssignable<Promise<number | undefined>>(cache.get<string>('key'));
 
-expectType<Promise<void>>(cache.set('key', 1));
-expectType<Promise<void>>(cache.set('key', true));
-expectType<Promise<void>>(cache.set('key', [true, 'string']));
-expectType<Promise<void>>(cache.set('key', {wow: [true, 'string']}));
-expectType<Promise<void>>(cache.set('key', 1, 1));
+expectAssignable<Promise<number>>(cache.set('key', 1));
+expectAssignable<Promise<boolean>>(cache.set('key', true));
+expectAssignable<Promise<[boolean, string]>>(cache.set('key', [true, 'string']));
+expectAssignable<Promise<Record<string, any[]>>>(cache.set('key', {wow: [true, 'string']}));
+expectAssignable<Promise<number>>(cache.set('key', 1, 1));
 
 const cachedPower = cache.function((n: number) => n ** 1000);
 expectType<(n: number) => Promise<number>>(cachedPower);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,19 +21,22 @@ const cachedPower = cache.function((n: number) => n ** 1000);
 expectType<(n: number) => Promise<number>>(cachedPower);
 expectType<number>(await cachedPower(1));
 
-expectType<(n: string) => Promise<number>>(cache.function(
-	(n: string) => Number(n)
-));
+expectType<(n: string) => Promise<number>>(
+	cache.function((n: string) => Number(n))
+);
 
-expectType<(n: string) => Promise<number>>(cache.function(
-	(n: string) => Number(n)
-	, {
+expectType<(n: string) => Promise<number>>(
+	cache.function(async (n: string) => Number(n))
+);
+
+expectType<(n: string) => Promise<number>>(
+	cache.function((n: string) => Number(n), {
 		expiration: 20
-	}));
+	})
+);
 
-expectType<(date: Date) => Promise<string>>(cache.function(
-	(date: Date) => String(date.getHours())
-	, {
+expectType<(date: Date) => Promise<string>>(
+	cache.function((date: Date) => String(date.getHours()), {
 		cacheKey: ([date]) => date.toLocaleString()
-	}));
-
+	})
+);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -17,38 +17,37 @@ expectAssignable<Promise<[boolean, string]>>(cache.set('key', [true, 'string']))
 expectAssignable<Promise<Record<string, any[]>>>(cache.set('key', {wow: [true, 'string']}));
 expectAssignable<Promise<number>>(cache.set('key', 1, 1));
 
-const cachedPower = cache.function((n: number) => n ** 1000);
+const cachedPower = cache.function(async (n: number) => n ** 1000);
 expectType<(n: number) => Promise<number>>(cachedPower);
 expectType<number>(await cachedPower(1));
 
 expectType<(n: string) => Promise<number>>(
-	cache.function((n: string) => Number(n))
+	cache.function(async (n: string) => Number(n))
 );
 
 expectType<(n: string) => Promise<number>>(
 	cache.function(async (n: string) => Number(n))
 );
 
-function identity(x: string): string;
-function identity(x: number): number;
-function identity(x: number | string): number | string {
+async function identity(x: string): Promise <string>;
+async function identity(x: number): Promise <number>;
+async function identity(x: number | string): Promise <number | string> {
 	return x;
 }
 
-// TODO: Overloads are failing
 expectType<Promise<number>>(cache.function(identity)(1));
-/// expectType<Promise<string>>(cache.function(identity)('1'));
+expectType<Promise<string>>(cache.function(identity)('1'));
 expectNotAssignable<Promise<string>>(cache.function(identity)(1));
-/// expectNotAssignable<Promise<number>>(cache.function(identity)('1'));
+expectNotAssignable<Promise<number>>(cache.function(identity)('1'));
 
 expectType<(n: string) => Promise<number>>(
-	cache.function((n: string) => Number(n), {
+	cache.function(async (n: string) => Number(n), {
 		expiration: 20
 	})
 );
 
 expectType<(date: Date) => Promise<string>>(
-	cache.function((date: Date) => String(date.getHours()), {
+	cache.function(async (date: Date) => String(date.getHours()), {
 		cacheKey: ([date]) => date.toLocaleString()
 	})
 );

--- a/index.ts
+++ b/index.ts
@@ -90,14 +90,14 @@ interface MemoizedFunctionOptions<TArgs extends any[]> {
 
 function function_<
 	TValue extends Value,
-	TArgs extends any[],
-	TFunction extends (...args: TArgs) => Promise<TValue>
+	TFunction extends (...args: any[]) => Promise<TValue>,
+	TArgs extends Parameters<TFunction>
 >(
 	getter: TFunction,
 	options: MemoizedFunctionOptions<TArgs> = {}
 ): TFunction {
-	return (async (...args) => {
-		const key = options.cacheKey ? options.cacheKey(args) : args[0];
+	return (async (...args: TArgs) => {
+		const key = options.cacheKey ? options.cacheKey(args) : args[0] as string;
 		const cachedValue = await get<TValue>(key);
 		if (cachedValue !== undefined) {
 			return cachedValue;

--- a/index.ts
+++ b/index.ts
@@ -90,7 +90,7 @@ type Unpromise<MaybePromise> = MaybePromise extends Promise<infer Type> ? Type :
 type AsyncReturnType<T extends AnyFunction> = Unpromise<ReturnType<T>>
 type PromisedFunction<T extends AnyFunction> = (...args: Parameters<T>) => Promise<AsyncReturnType<T>>;
 
-interface MemoizedFunctionOptions<TFunction extends (...args: any[]) => any> {
+interface MemoizedFunctionOptions<TFunction extends AnyFunction> {
 	expiration?: number;
 	cacheKey?: (args: Parameters<TFunction>) => string;
 }

--- a/index.ts
+++ b/index.ts
@@ -85,23 +85,17 @@ async function purge(): Promise<void> {
 	}
 }
 
-// Automatically clear cache every day
-if (isBackgroundPage()) {
-	setTimeout(purge, 60000); // Purge cache on launch, but wait a bit
-	setInterval(purge, 1000 * 3600 * 24);
-}
+type AnyFunction = (...args: any[]) => any;
+type Unpromise<MaybePromise> = MaybePromise extends Promise<infer Type> ? Type : MaybePromise;
+type AsyncReturnType<T extends AnyFunction> = Unpromise<ReturnType<T>>
+type PromisedFunction<T extends AnyFunction> = (...args: Parameters<T>) => Promise<AsyncReturnType<T>>;
 
 interface MemoizedFunctionOptions<TFunction extends (...args: any[]) => any> {
 	expiration?: number;
 	cacheKey?: (args: Parameters<TFunction>) => string;
 }
 
-type Unpromise<MaybePromise> = MaybePromise extends Promise<infer Type> ? Type : MaybePromise;
-type AsyncReturnType<T extends (...args: any) => any> = Unpromise<ReturnType<T>>
-type PromisedFunction<T extends (...args: any[]) => any> =
-	(...args: Parameters<T>) => Promise<AsyncReturnType<T>>;
-
-function function_<TFunction extends(...args: any[]) => any>(
+function function_<TFunction extends AnyFunction>(
 	function_: TFunction,
 	{
 		cacheKey = defaultCacheKey,
@@ -120,6 +114,16 @@ function function_<TFunction extends(...args: any[]) => any>(
 		return freshValue;
 	};
 }
+
+function init(): void {
+	// Automatically clear cache every day
+	if (isBackgroundPage()) {
+		setTimeout(purge, 60000); // Purge cache on launch, but wait a bit
+		setInterval(purge, 1000 * 3600 * 24);
+	}
+}
+
+init();
 
 export default {
 	has,

--- a/index.ts
+++ b/index.ts
@@ -96,8 +96,10 @@ interface MemoizedFunctionOptions<TFunction extends (...args: any[]) => any> {
 	cacheKey?: (args: Parameters<TFunction>) => string;
 }
 
+type Unpromise<MaybePromise> = MaybePromise extends Promise<infer Type> ? Type : MaybePromise;
+type AsyncReturnType<T extends (...args: any) => any> = Unpromise<ReturnType<T>>
 type PromisedFunction<T extends (...args: any[]) => any> =
-	(...args: Parameters<T>) => Promise<ReturnType<T>>;
+	(...args: Parameters<T>) => Promise<AsyncReturnType<T>>;
 
 function function_<TFunction extends(...args: any[]) => any>(
 	function_: TFunction,

--- a/index.ts
+++ b/index.ts
@@ -56,14 +56,16 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 	return value.data;
 }
 
-async function set<TValue extends Value>(key: string, value: TValue, expiration: number = defaultExpiration /* days */): Promise<void> {
+async function set<TValue extends Value>(key: string, value: TValue, expiration: number = defaultExpiration /* days */): Promise<TValue> {
 	const cachedKey = `cache:${key}`;
-	return p(_set, {
+	await p(_set, {
 		[cachedKey]: {
 			data: value,
 			expiration: Date.now() + (1000 * 3600 * 24 * expiration)
 		}
 	});
+
+	return value;
 }
 
 async function delete_(key: string): Promise<void> {

--- a/index.ts
+++ b/index.ts
@@ -91,21 +91,22 @@ interface MemoizedFunctionOptions<TArgs extends any[]> {
 function function_<
 	TValue extends Value,
 	TArgs extends any[],
+	TFunction extends (...args: TArgs) => Promise<TValue>
 >(
-	function_: (...args: TArgs) => Promise<TValue> | TValue,
+	getter: TFunction,
 	options: MemoizedFunctionOptions<TArgs> = {}
-): (...args: TArgs) => Promise<TValue> {
-	return async (...args) => {
+): TFunction {
+	return (async (...args) => {
 		const key = options.cacheKey ? options.cacheKey(args) : args[0];
 		const cachedValue = await get<TValue>(key);
 		if (cachedValue !== undefined) {
 			return cachedValue;
 		}
 
-		const freshValue = await function_(...args);
+		const freshValue = await getter(...args);
 		await set<TValue>(key, freshValue, options.expiration);
 		return freshValue;
-	};
+	}) as TFunction;
 }
 
 function init(): void {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-storage-cache",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "WebExtensions module: Map-like promised cache storage with expiration. Chrome and Firefox.",
   "keywords": [
     "await",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-storage-cache",
-  "version": "1.0.2",
+  "version": "2.0.0-0",
   "description": "WebExtensions module: Map-like promised cache storage with expiration. Chrome and Firefox.",
   "keywords": [
     "await",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "module": "index.js",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "tsc --silent",
+    "prepublishOnly": "tsc",
     "test": "run-s build test:*",
     "test:xo": "xo",
     "test:tsd": "tsd; true",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webext-storage-cache",
-  "version": "2.0.0-1",
+  "version": "1.0.2",
   "description": "WebExtensions module: Map-like promised cache storage with expiration. Chrome and Firefox.",
   "keywords": [
     "await",

--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
   "devDependencies": {
     "@sindresorhus/tsconfig": "^0.6.0",
     "@types/chrome": "0.0.91",
-    "@typescript-eslint/eslint-plugin": "^2.9.0",
-    "@typescript-eslint/parser": "^2.9.0",
+    "@typescript-eslint/eslint-plugin": "^2.10.0",
+    "@typescript-eslint/parser": "^2.10.0",
     "eslint-config-xo-typescript": "^0.23.0",
     "npm-run-all": "^4.1.5",
     "tsd": "^0.11.0",
-    "typescript": "^3.5.0",
+    "typescript": "^3.7.3",
     "xo": "*"
   },
   "type": "module"

--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,24 @@ import cache from 'webext-storage-cache';
 })();
 ```
 
+The same code could be also written more effectively with `cache.function`:
+
+```js
+import cache from 'webext-storage-cache';
+
+const cachedFunction = cache.function(someFunction, {
+	expiration: 3,
+	cacheKey: () => 'unique'
+});
+
+(async () => {
+  console.log(await cachedFunction());
+})();
+```
+
 ## API
 
-Similar to a `Map()`, but **all methods a return a `Promise`.**
+Similar to a `Map()`, but **all methods a return a `Promise`.** It also has a memoization method that hides the caching logic and makes it a breeze to use.
 
 ### cache.has(key)
 
@@ -80,10 +95,10 @@ Type: `string | number | boolean` or `array | object` of those three types
 
 #### expiration
 
-The number of days after which the cache item will expire.
-
 Type: `number`
 Default: 30
+
+The number of days after which the cache item will expire.
 
 ### cache.delete(key)
 
@@ -92,6 +107,51 @@ Deletes the requested item from the cache.
 #### key
 
 Type: `string`
+
+### cache.function(getter, options)
+
+Caches the return value of the function based on the `cacheKey`. It works similarly to `lodash.memoize`:
+
+```js
+async function getHTML(url, options) {
+	const response = await fetch(url, options);
+	return response.text();
+}
+
+const cachedGetHTML = cache.memoized(getHTML);
+
+const html = await cachedGetHTML('https://google.com', {});
+// The HTML of google.com will be saved with the key 'https://google.com'
+```
+
+#### getter
+
+Type: `async function` that returns a cacheable value.
+
+#### options
+
+##### cacheKey
+
+Type: `function` that returns a string
+Default: `function` that returns the first argument of the call
+
+```js
+const cachedOperate = cache.memoized(operate, {
+	cacheKey: args => args.join(',')
+});
+
+cachedOperate(1, 2, 3);
+// The result of `operate(1, 2, 3)` will be stored in the key '1,2,3'
+// Without a custom `cacheKey`, it would be stored in the key '1'
+```
+
+
+##### expiration
+
+Type: `number`
+Default: 30
+
+The number of days after which the cache item will expire.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ import cache from 'webext-storage-cache';
 
 ## API
 
-Similar to a `Map()`, but all methods a return a `Promise`.
+Similar to a `Map()`, but **all methods a return a `Promise`.**
 
 ### cache.has(key)
 
@@ -68,7 +68,7 @@ Type: `string`
 
 ### cache.set(key, value, expiration /* in days */)
 
-Caches the given key and value for a given amount of days.
+Caches the given key and value for a given amount of days. It returns the value itself.
 
 #### key
 

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Type: `string | number | boolean` or `array | object` of those three types
 
 #### expiration
 
-Type: `number`
+Type: `number`<br>
 Default: 30
 
 The number of days after which the cache item will expire.
@@ -118,7 +118,7 @@ async function getHTML(url, options) {
 	return response.text();
 }
 
-const cachedGetHTML = cache.memoized(getHTML);
+const cachedGetHTML = cache.function(getHTML);
 
 const html = await cachedGetHTML('https://google.com', {});
 // The HTML of google.com will be saved with the key 'https://google.com'
@@ -136,7 +136,7 @@ Type: `function` that returns a string
 Default: `function` that returns the first argument of the call
 
 ```js
-const cachedOperate = cache.memoized(operate, {
+const cachedOperate = cache.function(operate, {
 	cacheKey: args => args.join(',')
 });
 
@@ -148,7 +148,7 @@ cachedOperate(1, 2, 3);
 
 ##### expiration
 
-Type: `number`
+Type: `number`<br>
 Default: 30
 
 The number of days after which the cache item will expire.


### PR DESCRIPTION
This PR lets you skip the whole `if cached, return cached, else get new value and cache it`

# Before

```js
async function cachedExpensiveCall() {
	const cached = await cache.get<string>('key');
	if (cached) {
		return cached;
	}

	const data = await expensiveCall();
	await cache.set('key', data, 5);
	return data;
}
```

# After

```js
const cachedExpensiveCall = cache.memoized(expensiveCall, {
	expiration: 5,
	cacheKey: () => 'key'
});
```

# Next steps

- [x] Fix tsd
- [x] Add documentation
- [ ] Release as new major because I dropped the CJS bundle in a previous commit