### PR TITLE
Accept `undefined` in `.set` and `.function` (skips the cache)

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -51,3 +51,8 @@ expectType<(date: Date) => Promise<string>>(
 		cacheKey: ([date]) => date.toLocaleString()
 	})
 );
+
+// This function won't be cached
+expectType<(n: undefined[]) => Promise<undefined>>(
+	cache.function(async (n: undefined[]) => n[1])
+);

--- a/index.ts
+++ b/index.ts
@@ -53,6 +53,10 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 }
 
 async function set<TValue extends Value>(key: string, value: TValue, expiration = 30 /* days */): Promise<TValue> {
+	if (typeof value === 'undefined') {
+		return;
+	}
+
 	const cachedKey = `cache:${key}`;
 	await p(_set, {
 		[cachedKey]: {
@@ -99,7 +103,7 @@ interface MemoizedFunctionOptions<TArgs extends any[], TValue> {
 
 function function_<
 	TValue extends Value,
-	TFunction extends (...args: any[]) => Promise<TValue>,
+	TFunction extends (...args: any[]) => Promise<TValue | undefined>,
 	TArgs extends Parameters<TFunction>
 >(
 	getter: TFunction,

--- a/index.ts
+++ b/index.ts
@@ -117,7 +117,7 @@ function function_<
 		}
 
 		const freshValue = await getter(...args);
-		await set<TValue>(key, freshValue, options.expiration);
+		await set<TValue>(key, freshValue!, options.expiration);
 		return freshValue;
 	}) as TFunction;
 }

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,7 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 
 async function set<TValue extends Value>(key: string, value: TValue, expiration = 30 /* days */): Promise<TValue> {
 	if (typeof value === 'undefined') {
+		// @ts-ignore This never happens in TS because `value` can't be undefined
 		return;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,9 @@ Type: `string`
 
 #### value
 
-Type: `string | number | boolean` or `array | object` of those three types
+Type: `string | number | boolean` or `array | object` of those three types.
+
+`undefined` won't be cached, it's considered "no value" in the Storage API.
 
 #### expiration
 
@@ -152,6 +154,8 @@ const html = await cachedGetHTML('https://google.com', {});
 
 Type: `async function` that returns a cacheable value.
 
+Returning `undefined` will skip the cache, just like `cache.set()`.
+
 #### options
 
 ##### cacheKey
@@ -184,8 +188,8 @@ Default: `() => false`
 You may want to have additional checks on the cached value, for example after updating its format.
 
 ```js
-async function getContent(url, options) {
-	const response = await fetch(url, options);
+async function getContent(url) {
+	const response = await fetch(url);
 	return response.json(); // For example, you used to return plain text, now you return a JSON object
 }
 
@@ -194,7 +198,7 @@ const cachedGetContent = cache.function(getContent, {
 	isExpired: cachedValue => typeof cachedValue === 'string'
 });
 
-const json = await cachedGetHTML('https://google.com', {});
+const json = await cachedGetHTML('https://google.com');
 // The HTML of google.com will be saved with the key 'https://google.com'
 ```
 


### PR DESCRIPTION
Related to https://github.com/sindresorhus/refined-github/pull/2667#discussion_r370932244