### PR TITLE
Add `stale-while-revalidate` behavior

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -46,6 +46,13 @@ expectType<(n: string) => Promise<number>>(
 	})
 );
 
+expectType<(n: string) => Promise<number>>(
+	cache.function(async (n: string) => Number(n), {
+		maxAge: 20,
+		staleWhileRevalidate: 5
+	})
+);
+
 expectType<(date: Date) => Promise<string>>(
 	cache.function(async (date: Date) => String(date.getHours()), {
 		cacheKey: ([date]) => date.toLocaleString()

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "repository": "fregante/webext-storage-cache",
   "license": "MIT",
-  "author": "Connor Love",
+  "author": "Federico Brigante <opensource@bfred.it> (bfred.it)",
   "contributors": [
-    "Federico Brigante <opensource@bfred.it> (bfred.it)"
+    "Connor Love"
   ],
   "type": "module",
   "main": "index.js",

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,32 @@ Default: 30
 
 The number of days after which the cache item will expire.
 
+##### staleWhileRevalidate
+
+Type: `number`<br>
+Default: `0` (disabled)
+
+Specifies how many additional days an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
+
+```js
+const cachedOperate = cache.function(operate, {
+	maxAge: 10,
+	staleWhileRevalidate: 2
+});
+
+cachedOperate(); // It will run `operate` and cache it for 10 days
+cachedOperate(); // It will return the cache
+
+/* 11 days later, cache is expired, but still there */
+
+cachedOperate(); // It will return the cache
+// Asynchronously, it will also run `operate` and cache the new value for 10 more days
+
+/* 13 days later, cache is expired and deleted */
+
+cachedOperate(); // It will run `operate` and cache it for 10 days
+```
+
 ##### shouldRevalidate
 
 Type: `function` that returns a boolean<br>


### PR DESCRIPTION
Think of it as a `stale-while-revalidate`.

`expiration: 30` means the cache is evicted after 30 days
`keepFresh: 10` means the cache is considered stale after 10 days (i.e. use it instantly, but update it asynchronously)