### PR TITLE
Accept age in seconds, not days

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,8 +13,8 @@ const getPromise = (executor: () => void) => <T>(key?): Promise<T> => new Promis
 	});
 });
 
-function millisecondsFromNow(milliseconds: number): number {
-	return Date.now() + milliseconds;
+function getFutureTimeStampFromSeconds(seconds: number): number {
+	return Date.now() + seconds * 1000;
 }
 
 function days(days: number): number {
@@ -77,7 +77,7 @@ async function set<TValue extends Value>(key: string, value: TValue, maxAge = da
 	await _set({
 		[internalKey]: {
 			data: value,
-			maxAge: millisecondsFromNow(maxAge)
+			maxAge: getFutureTimeStampFromSeconds(maxAge)
 		}
 	});
 
@@ -145,8 +145,8 @@ function function_<
 			return getSet(userKey, args);
 		}
 
-		// When the expiration is earlier than the number of days specified by `staleWhileRevalidate`, it means `maxAge` has already passed and therefore the cache is stale.
-		if (millisecondsFromNow(staleWhileRevalidate) > cachedItem.maxAge) {
+		// When the item expires earlier than what `staleWhileRevalidate` suggest, it means that the `maxAge` argument has already passed and therefore the cache is stale
+		if (cachedItem.maxAge < getFutureTimeStampFromSeconds(staleWhileRevalidate)) {
 			setTimeout(getSet, 0, userKey, args);
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Similar to a `Map()`, but **all methods a return a `Promise`.** It also has a me
 
 ### cache.days(days)
 
-Utility method to convert days to milliseconds, to be used as `maxAge` or `staleWhileRevalidate`
+Utility method to convert days to seconds, to be used as `maxAge` or `staleWhileRevalidate`
 
 ```js
 cache.days(1);
@@ -74,7 +74,7 @@ cache.days(1);
 
 ### cache.hours(hours)
 
-Utility method to convert days to milliseconds, to be used as `maxAge` or `staleWhileRevalidate`
+Utility method to convert days to seconds, to be used as `maxAge` or `staleWhileRevalidate`
 
 ```js
 cache.hours(1);
@@ -107,9 +107,9 @@ const url = await cache.get('cached-url');
 
 Type: `string`
 
-### cache.set(key, value, maxAge /* in milliseconds */)
+### cache.set(key, value, maxAge /* in seconds */)
 
-Caches the given key and value for a given amount of milliseconds. It returns the value itself.
+Caches the given key and value for a given amount of seconds. It returns the value itself.
 
 ```js
 const info = await getInfoObject();
@@ -131,7 +131,7 @@ Type: `string | number | boolean` or `array | object` of those three types.
 Type: `number`<br>
 Default: `cache.days(30)`, which is the same as `30 * 24 * 3600 * 1000`
 
-The number of milliseconds after which the cache item will expire.
+The number of seconds after which the cache item will expire.
 
 ### cache.delete(key)
 
@@ -197,14 +197,14 @@ cachedOperate(1, 2, 3);
 Type: `number`<br>
 Default: `cache.days(30)`, which is the same as `30 * 24 * 3600 * 1000`
 
-The number of milliseconds after which the cache item will expire.
+The number of seconds after which the cache item will expire.
 
 ##### staleWhileRevalidate
 
 Type: `number`<br>
 Default: `0` (disabled)
 
-Specifies how many additional milliseconds an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
+Specifies how many additional seconds an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
 
 ```js
 const cachedOperate = cache.function(operate, {

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ import cache from 'webext-storage-cache';
 (async () => {
 	if (!await cache.has('unique')) {
 		const cachableItem = await someFunction();
-		await cache.set('unique', cachableItem, 3 /* days */);
+		await cache.set('unique', cachableItem, cache.days(3));
 	}
 
 	console.log(await cache.get('unique'));
@@ -61,6 +61,25 @@ const cachedFunction = cache.function(someFunction, {
 ## API
 
 Similar to a `Map()`, but **all methods a return a `Promise`.** It also has a memoization method that hides the caching logic and makes it a breeze to use.
+
+
+### cache.days(days)
+
+Utility method to convert days to milliseconds, to be used as `maxAge` or `staleWhileRevalidate`
+
+```js
+cache.days(1);
+// 86400
+```
+
+### cache.hours(hours)
+
+Utility method to convert days to milliseconds, to be used as `maxAge` or `staleWhileRevalidate`
+
+```js
+cache.hours(1);
+// 3600
+```
 
 ### cache.has(key)
 
@@ -88,9 +107,9 @@ const url = await cache.get('cached-url');
 
 Type: `string`
 
-### cache.set(key, value, maxAge /* in days */)
+### cache.set(key, value, maxAge /* in milliseconds */)
 
-Caches the given key and value for a given amount of days. It returns the value itself.
+Caches the given key and value for a given amount of milliseconds. It returns the value itself.
 
 ```js
 const info = await getInfoObject();
@@ -110,9 +129,9 @@ Type: `string | number | boolean` or `array | object` of those three types.
 #### maxAge
 
 Type: `number`<br>
-Default: 30
+Default: `cache.days(30)`, which is the same as `30 * 24 * 3600 * 1000`
 
-The number of days after which the cache item will expire.
+The number of milliseconds after which the cache item will expire.
 
 ### cache.delete(key)
 
@@ -176,20 +195,20 @@ cachedOperate(1, 2, 3);
 ##### maxAge
 
 Type: `number`<br>
-Default: 30
+Default: `cache.days(30)`, which is the same as `30 * 24 * 3600 * 1000`
 
-The number of days after which the cache item will expire.
+The number of milliseconds after which the cache item will expire.
 
 ##### staleWhileRevalidate
 
 Type: `number`<br>
 Default: `0` (disabled)
 
-Specifies how many additional days an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
+Specifies how many additional milliseconds an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
 
 ```js
 const cachedOperate = cache.function(operate, {
-	maxAge: 10,
+	maxAge: cache.days(10),
 	staleWhileRevalidate: 2
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -59,8 +59,8 @@ test.serial('set() with value', async t => {
 	const arguments_ = chrome.storage.local.set.lastCall.args[0];
 	t.deepEqual(Object.keys(arguments_), ['cache:name']);
 	t.is(arguments_['cache:name'].data, 'Anne');
-	t.true(arguments_['cache:name'].maxAge > millisecondsInTheFuture(maxAge - cache.days(0.5)));
-	t.true(arguments_['cache:name'].maxAge < millisecondsInTheFuture(maxAge + cache.days(0.5)));
+	t.true(arguments_['cache:name'].maxAge > millisecondsFromNow(maxAge - cache.days(0.5)));
+	t.true(arguments_['cache:name'].maxAge < millisecondsFromNow(maxAge + cache.days(0.5)));
 });
 
 test.serial('function() with empty cache', async t => {
@@ -109,8 +109,8 @@ test.serial('function() with empty cache and staleWhileRevalidate', async t => {
 	t.is(arguments_['cache:@anne'].data, 'ANNE');
 
 	const expectedExpiration = maxAge + staleWhileRevalidate;
-	t.true(arguments_['cache:@anne'].maxAge > millisecondsInTheFuture(expectedExpiration - cache.days(0.5)));
-	t.true(arguments_['cache:@anne'].maxAge < millisecondsInTheFuture(expectedExpiration + cache.days(0.5)));
+	t.true(arguments_['cache:@anne'].maxAge > millisecondsFromNow(expectedExpiration - cache.days(0.5)));
+	t.true(arguments_['cache:@anne'].maxAge < millisecondsFromNow(expectedExpiration + cache.days(0.5)));
 });
 
 test.serial('function() with fresh cache and staleWhileRevalidate', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,12 @@ import cache from '../index.js';
 
 const getUsernameDemo = async name => name.slice(1).toUpperCase();
 
-function millisecondsFromNow(milliseconds) {
-	return Date.now() + milliseconds;
+function getFutureTimestampFromSeconds(seconds) {
+	return Date.now() + seconds;
+}
+
+function isTimestampWithinRange(actual, expected) {
+	return expected * 0.95 < actual && actual < expected * 1.05;
 }
 
 function createCache(daysFromToday, wholeCache) {
@@ -15,7 +19,7 @@ function createCache(daysFromToday, wholeCache) {
 			.withArgs(key)
 			.yields({[key]: {
 				data,
-				maxAge: millisecondsFromNow(cache.days(daysFromToday))
+				maxAge: getFutureTimestampFromSeconds(cache.days(daysFromToday))
 			}});
 	}
 }
@@ -59,8 +63,7 @@ test.serial('set() with value', async t => {
 	const arguments_ = chrome.storage.local.set.lastCall.args[0];
 	t.deepEqual(Object.keys(arguments_), ['cache:name']);
 	t.is(arguments_['cache:name'].data, 'Anne');
-	t.true(arguments_['cache:name'].maxAge > millisecondsFromNow(maxAge - cache.days(0.5)));
-	t.true(arguments_['cache:name'].maxAge < millisecondsFromNow(maxAge + cache.days(0.5)));
+	t.true(isTimestampWithinRange(arguments_['cache:name'].maxAge, getFutureTimestampFromSeconds(maxAge));
 });
 
 test.serial('function() with empty cache', async t => {
@@ -109,8 +112,7 @@ test.serial('function() with empty cache and staleWhileRevalidate', async t => {
 	t.is(arguments_['cache:@anne'].data, 'ANNE');
 
 	const expectedExpiration = maxAge + staleWhileRevalidate;
-	t.true(arguments_['cache:@anne'].maxAge > millisecondsFromNow(expectedExpiration - cache.days(0.5)));
-	t.true(arguments_['cache:@anne'].maxAge < millisecondsFromNow(expectedExpiration + cache.days(0.5)));
+	t.true(isTimestampWithinRange(arguments_['cache:@anne'].maxAge, getFutureTimestampFromSeconds(expectedExpiration));
 });
 
 test.serial('function() with fresh cache and staleWhileRevalidate', async t => {


### PR DESCRIPTION
Breaking.

1. Seconds is the standard in HTTP cache, from which this API copies its nomenclature
2. While setting days is easier, setting hours is a mess: `maxAge: 1 / 24 * 2` means…?

This PR preserves both the ease of setting days (`maxAge: cache.days(30)`) and the _standardness_ of seconds