### PR TITLE
Use objects to define readable expiration values

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,7 +15,7 @@ expectAssignable<Promise<number>>(cache.set('key', 1));
 expectAssignable<Promise<boolean>>(cache.set('key', true));
 expectAssignable<Promise<[boolean, string]>>(cache.set('key', [true, 'string']));
 expectAssignable<Promise<Record<string, any[]>>>(cache.set('key', {wow: [true, 'string']}));
-expectAssignable<Promise<number>>(cache.set('key', 1, 1));
+expectAssignable<Promise<number>>(cache.set('key', 1, {days: 1}));
 
 const cachedPower = cache.function(async (n: number) => n ** 1000);
 expectType<(n: number) => Promise<number>>(cachedPower);
@@ -42,14 +42,14 @@ expectNotAssignable<Promise<number>>(cache.function(identity)('1'));
 
 expectType<(n: string) => Promise<number>>(
 	cache.function(async (n: string) => Number(n), {
-		maxAge: 20
+		maxAge: {days: 20}
 	})
 );
 
 expectType<(n: string) => Promise<number>>(
 	cache.function(async (n: string) => Number(n), {
-		maxAge: 20,
-		staleWhileRevalidate: 5
+		maxAge: {days: 20},
+		staleWhileRevalidate: {days: 5}
 	})
 );
 

--- a/index.ts
+++ b/index.ts
@@ -14,8 +14,8 @@ const getPromise = (executor: () => void) => <T>(key?): Promise<T> => new Promis
 	});
 });
 
-function timeInTheFuture(time: number): number {
-	return Date.now() + time;
+function timeInTheFuture(time: TimeDescriptor): number {
+	return Date.now() + toMilliseconds(time);
 }
 
 // @ts-ignore
@@ -70,7 +70,7 @@ async function set<TValue extends Value>(key: string, value: TValue, maxAge: Tim
 	await _set({
 		[internalKey]: {
 			data: value,
-			maxAge: timeInTheFuture(toMilliseconds(maxAge))
+			maxAge: timeInTheFuture(maxAge)
 		}
 	});
 
@@ -140,7 +140,7 @@ function function_<
 		}
 
 		// When the expiration is earlier than the number of days specified by `staleWhileRevalidate`, it means `maxAge` has already passed and therefore the cache is stale.
-		if (timeInTheFuture(toMilliseconds(maxAge)) > cachedItem.maxAge) {
+		if (timeInTheFuture(maxAge) > cachedItem.maxAge) {
 			setTimeout(getSet, 0, userKey, args);
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -140,7 +140,7 @@ function function_<
 		}
 
 		// When the expiration is earlier than the number of days specified by `staleWhileRevalidate`, it means `maxAge` has already passed and therefore the cache is stale.
-		if (timeInTheFuture(maxAge) > cachedItem.maxAge) {
+		if (timeInTheFuture(staleWhileRevalidate) > cachedItem.maxAge) {
 			setTimeout(getSet, 0, userKey, args);
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -125,7 +125,8 @@ function function_<
 			await delete_(key);
 			return;
 		}
-		const milliseconds = toMilliseconds(maxAge) + toMilliseconds(staleWhileRevalidate)
+
+		const milliseconds = toMilliseconds(maxAge) + toMilliseconds(staleWhileRevalidate);
 
 		return set<TValue>(key, freshValue, {milliseconds});
 	};

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     ]
   },
   "dependencies": {
+    "@sindresorhus/to-milliseconds": "^1.2.0",
     "webext-detect-page": "^2.0.2"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,9 @@ import cache from 'webext-storage-cache';
 (async () => {
 	if (!await cache.has('unique')) {
 		const cachableItem = await someFunction();
-		await cache.set('unique', cachableItem, 3 /* days */);
+		await cache.set('unique', cachableItem, {
+			days: 3
+		});
 	}
 
 	console.log(await cache.get('unique'));
@@ -49,7 +51,9 @@ The same code could be also written more effectively with `cache.function`:
 import cache from 'webext-storage-cache';
 
 const cachedFunction = cache.function(someFunction, {
-	maxAge: 3,
+	maxAge: {
+		days: 3
+	},
 	cacheKey: () => 'unique'
 });
 
@@ -88,9 +92,9 @@ const url = await cache.get('cached-url');
 
 Type: `string`
 
-### cache.set(key, value, maxAge /* in days */)
+### cache.set(key, value, maxAge)
 
-Caches the given key and value for a given amount of days. It returns the value itself.
+Caches the given key and value for a given amount of time. It returns the value itself.
 
 ```js
 const info = await getInfoObject();
@@ -109,10 +113,10 @@ Type: `string | number | boolean` or `array | object` of those three types.
 
 #### maxAge
 
-Type: `number`<br>
-Default: 30
+Type: [`TimeDescriptor`](https://github.com/sindresorhus/to-milliseconds#input)<br>
+Default: `{days: 30}`
 
-The number of days after which the cache item will expire.
+The amount of time after which the cache item will expire.
 
 ### cache.delete(key)
 
@@ -175,22 +179,26 @@ cachedOperate(1, 2, 3);
 
 ##### maxAge
 
-Type: `number`<br>
-Default: 30
+Type: [`TimeDescriptor`](https://github.com/sindresorhus/to-milliseconds#input)<br>
+Default: `{days: 30}`
 
-The number of days after which the cache item will expire.
+The amount of time after which the cache item will expire.
 
 ##### staleWhileRevalidate
 
-Type: `number`<br>
-Default: `0` (disabled)
+Type: [`TimeDescriptor`](https://github.com/sindresorhus/to-milliseconds#input)<br>
+Default: `{days: 0}` (disabled)
 
-Specifies how many additional days an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
+Specifies how many additional time an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
 
 ```js
 const cachedOperate = cache.function(operate, {
-	maxAge: 10,
-	staleWhileRevalidate: 2
+	maxAge: {
+		days: 10
+	},
+	staleWhileRevalidate: {
+		days: 2
+	}
 });
 
 cachedOperate(); // It will run `operate` and cache it for 10 days

--- a/readme.md
+++ b/readme.md
@@ -189,7 +189,7 @@ The amount of time after which the cache item will expire.
 Type: [`TimeDescriptor`](https://github.com/sindresorhus/to-milliseconds#input)<br>
 Default: `{days: 0}` (disabled)
 
-Specifies how many additional time an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call should return an updated and fresher item.
+Specifies how much longer an item should be kept in cache after its expiration. During this extra time, the item will still be served from cache instantly, but `getter` will be also called asynchronously to update the cache. A later call will return the updated and fresher item.
 
 ```js
 const cachedOperate = cache.function(operate, {


### PR DESCRIPTION
Fix #19, using `@sindresorhus/to-milliseconds`

Tests will be updated later