### PR TITLE
Allow `cache.set(x, undefined)` to delete the cached item

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 
 async function set<TValue extends Value>(key: string, value: TValue, maxAge: TimeDescriptor = {days: 30}): Promise<TValue> {
 	if (arguments.length < 2) {
-		throw new TypeError('Need a value');
+		throw new TypeError('Expected a value as the second argument');
 	}
 
 	if (typeof value === 'undefined') {

--- a/index.ts
+++ b/index.ts
@@ -74,16 +74,15 @@ async function set<TValue extends Value>(key: string, value: TValue, maxAge: Tim
 
 	if (typeof value === 'undefined') {
 		await delete_(key);
-		return value;
+	} else {
+		const internalKey = `cache:${key}`;
+		await storageSet({
+			[internalKey]: {
+				data: value,
+				maxAge: timeInTheFuture(maxAge)
+			}
+		});
 	}
-
-	const internalKey = `cache:${key}`;
-	await storageSet({
-		[internalKey]: {
-			data: value,
-			maxAge: timeInTheFuture(maxAge)
-		}
-	});
 
 	return value;
 }

--- a/index.ts
+++ b/index.ts
@@ -68,6 +68,10 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 }
 
 async function set<TValue extends Value>(key: string, value: TValue, maxAge: TimeDescriptor = {days: 30}): Promise<TValue> {
+	if (arguments.length < 2) {
+		throw new TypeError('Need a value');
+	}
+
 	if (typeof value === 'undefined') {
 		await delete_(key);
 		return value;

--- a/index.ts
+++ b/index.ts
@@ -68,7 +68,7 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 
 async function set<TValue extends Value>(key: string, value: TValue, maxAge: TimeDescriptor = {days: 30}): Promise<TValue> {
 	if (typeof value === 'undefined') {
-		await delete_(key);
+		return delete_(key);
 	}
 
 	const internalKey = `cache:${key}`;

--- a/index.ts
+++ b/index.ts
@@ -68,7 +68,8 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 
 async function set<TValue extends Value>(key: string, value: TValue, maxAge: TimeDescriptor = {days: 30}): Promise<TValue> {
 	if (typeof value === 'undefined') {
-		return delete_(key);
+		await delete_(key);
+		return value;
 	}
 
 	const internalKey = `cache:${key}`;

--- a/index.ts
+++ b/index.ts
@@ -68,8 +68,7 @@ async function get<TValue extends Value>(key: string): Promise<TValue | undefine
 
 async function set<TValue extends Value>(key: string, value: TValue, maxAge: TimeDescriptor = {days: 30}): Promise<TValue> {
 	if (typeof value === 'undefined') {
-		// @ts-ignore This never happens in TS because `value` can't be undefined
-		return;
+		await delete_(key);
 	}
 
 	const internalKey = `cache:${key}`;

--- a/test/index.js
+++ b/test/index.js
@@ -65,9 +65,10 @@ test.serial('has() with expired cache', async t => {
 });
 
 test.serial('set() with undefined', async t => {
+	await cache.set('name', 'Anne');
 	await cache.set('name');
-	// StorageArea.set should not be called with `undefined`
-	t.is(chrome.storage.local.set.callCount, 0);
+	// Cached value should be erased
+	t.is(await cache.has('name'), false);
 });
 
 test.todo('set() with past maxAge should throw');

--- a/test/index.js
+++ b/test/index.js
@@ -64,8 +64,8 @@ test.serial('has() with expired cache', async t => {
 	t.is(await cache.has('name'), false);
 });
 
-test.serial('set() with no value', async t => {
-	await t.throwsAsync(cache.set('name'), {instanceOf: TypeError, message: 'Need a value'});
+test.serial('set() without a value', async t => {
+	await t.throwsAsync(cache.set('name'), {instanceOf: TypeError, message: 'Expected a value as the second argument'});
 });
 
 test.serial('set() with undefined', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -64,9 +64,13 @@ test.serial('has() with expired cache', async t => {
 	t.is(await cache.has('name'), false);
 });
 
+test.serial('set() with no value', async t => {
+	await t.throwsAsync(cache.set('name'), {instanceOf: TypeError, message: 'Need a value'});
+});
+
 test.serial('set() with undefined', async t => {
 	await cache.set('name', 'Anne');
-	await cache.set('name');
+	await cache.set('name', undefined);
 	// Cached value should be erased
 	t.is(await cache.has('name'), false);
 });


### PR DESCRIPTION
This is a very basic fix for the issue #25 discovered in sindresorhus/refined-github#3589.

Fixes #25 