### PR TITLE
Only use the storage as cache, not memory

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -36,6 +36,7 @@ jobs:
       - run: webpack --entry ./index.js
       - run: cat dist/main.js
   Parcel:
+    if: false # https://github.com/parcel-bundler/parcel/issues/4155
     runs-on: ubuntu-latest
     needs: Pack
     steps:

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,12 @@ function function_<
 		return cachedItem.data;
 	}) as Getter;
 
-	const concurrentOnlyMemoizedFunction = pMemoize(internalGetSet);
+	const concurrentOnlyMemoizedFunction = pMemoize(internalGetSet, {
+		// @ts-expect-error any[]' is assignable to the constraint of type 'Arguments', but 'Arguments' could be instantiated with a different subtype of constraint 'any[]'.ts(2322)
+		// TODO: Fix type instead
+		cacheKey,
+		cache: false, // In-flight only
+	});
 
 	return Object.assign(concurrentOnlyMemoizedFunction, {
 		fresh: (async (...args: Arguments) => {

--- a/index.ts
+++ b/index.ts
@@ -13,11 +13,10 @@ type Value = Primitive | Primitive[] | Record<string, any>;
 // No circular references: Record<string, Value> https://github.com/Microsoft/TypeScript/issues/14174
 // No index signature: {[key: string]: Value} https://github.com/microsoft/TypeScript/issues/15300#issuecomment-460226926
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- TODO: When releasing a breaking release
-interface CacheItem<Value> {
+type CacheItem<Value> = {
 	data: Value;
 	maxAge: number;
-}
+};
 
 type Cache<ScopedValue extends Value = Value> = Record<string, CacheItem<ScopedValue>>;
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 	},
 	"dependencies": {
 		"@sindresorhus/to-milliseconds": "^2.0.0",
-		"p-memoize": "^7.1.1",
 		"webext-detect-page": "^4.0.1",
 		"webext-polyfill-kinda": "^1.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webext-storage-cache",
-	"version": "5.1.1",
+	"version": "6.0.0-0",
 	"description": "Map-like promised cache storage with expiration. WebExtensions module for Chrome, Firefox, Safari",
 	"keywords": [
 		"await",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"dependencies": {
 		"@sindresorhus/to-milliseconds": "^2.0.0",
-		"micro-memoize": "^4.0.14",
+		"p-memoize": "^7.1.1",
 		"webext-detect-page": "^4.0.1",
 		"webext-polyfill-kinda": "^1.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "webext-storage-cache",
-	"version": "6.0.0-0",
+	"version": "6.0.0-1",
 	"description": "Map-like promised cache storage with expiration. WebExtensions module for Chrome, Firefox, Safari",
 	"keywords": [
 		"await",

--- a/test/index.js
+++ b/test/index.js
@@ -274,10 +274,28 @@ test.serial('function() avoids concurrent function calls', async t => {
 	const call = cache.function(spy);
 
 	t.is(spy.callCount, 0);
-	const cacheMePlease = function () {};
-	t.is(call('@anne', cacheMePlease), call('@anne', cacheMePlease));
-	await call('@anne', cacheMePlease);
+	t.is(call('@anne'), call('@anne'));
+	await call('@anne');
 	t.is(spy.callCount, 1);
+
+	t.not(call('@new'), call('@other'));
+	await call('@idk');
+	t.is(spy.callCount, 4);
+});
+
+test.serial.skip('function() avoids concurrent function calls with complex arguments', async t => {
+	const spy = sinon.spy(async (transform, user) => transform(user.name));
+	const call = cache.function(spy);
+
+	t.is(spy.callCount, 0);
+	const cacheMePlease = name => name.slice(1).toUpperCase();
+	t.is(call(cacheMePlease, {name: '@anne'}), call(cacheMePlease, {name: '@anne'}));
+	await call(cacheMePlease, {name: '@anne'});
+	t.is(spy.callCount, 1);
+
+	t.not(call(cacheMePlease, {name: '@new'}), call(cacheMePlease, {name: '@other'}));
+	await call(cacheMePlease, {name: '@idk'});
+	t.is(spy.callCount, 4);
 });
 
 test.serial('function() always loads the data from storage, not memory', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -283,7 +283,7 @@ test.serial('function() avoids concurrent function calls', async t => {
 	t.is(spy.callCount, 4);
 });
 
-test.serial.skip('function() avoids concurrent function calls with complex arguments', async t => {
+test.serial.failing('function() avoids concurrent function calls with complex arguments', async t => {
 	const spy = sinon.spy(async (transform, user) => transform(user.name));
 	const call = cache.function(spy);
 

--- a/test/index.js
+++ b/test/index.js
@@ -255,12 +255,12 @@ test.serial('function() accepts custom cache key generator', async t => {
 
 test.serial('function() verifies cache with shouldRevalidate callback', async t => {
 	createCache(10, {
-		'cache:@anne': '@anne',
+		'cache:@anne': 'anne@',
 	});
 
 	const spy = sinon.spy(getUsernameDemo);
 	const call = cache.function(spy, {
-		shouldRevalidate: value => value.startsWith('@'),
+		shouldRevalidate: value => value.endsWith('@'),
 	});
 
 	t.is(await call('@anne'), 'ANNE');
@@ -269,7 +269,7 @@ test.serial('function() verifies cache with shouldRevalidate callback', async t 
 	t.is(spy.callCount, 1);
 });
 
-test.serial('function() avoids duplicate nearby function calls', async t => {
+test.serial('function() avoids concurrent function calls', async t => {
 	const spy = sinon.spy(getUsernameDemo);
 	const call = cache.function(spy);
 
@@ -278,6 +278,29 @@ test.serial('function() avoids duplicate nearby function calls', async t => {
 	t.is(call('@anne', cacheMePlease), call('@anne', cacheMePlease));
 	await call('@anne', cacheMePlease);
 	t.is(spy.callCount, 1);
+});
+
+test.serial('function() always loads the data from storage, not memory', async t => {
+	createCache(10, {
+		'cache:@anne': 'ANNE',
+	});
+
+	const spy = sinon.spy(getUsernameDemo);
+	const call = cache.function(spy);
+
+	t.is(await call('@anne'), 'ANNE');
+
+	t.is(chrome.storage.local.get.callCount, 1);
+	t.is(chrome.storage.local.get.lastCall.args[0], 'cache:@anne');
+
+	createCache(10, {
+		'cache:@anne': 'NEW ANNE',
+	});
+
+	t.is(await call('@anne'), 'NEW ANNE');
+
+	t.is(chrome.storage.local.get.callCount, 2);
+	t.is(chrome.storage.local.get.lastCall.args[0], 'cache:@anne');
 });
 
 test.serial('function.fresh() ignores cached value', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -283,9 +283,11 @@ test.serial('function() avoids concurrent function calls', async t => {
 	t.is(spy.callCount, 4);
 });
 
-test.serial.failing('function() avoids concurrent function calls with complex arguments', async t => {
+test.serial('function() avoids concurrent function calls with complex arguments via cacheKey', async t => {
 	const spy = sinon.spy(async (transform, user) => transform(user.name));
-	const call = cache.function(spy);
+	const call = cache.function(spy, {
+		cacheKey: ([fn, user]) => JSON.stringify([fn.name, user]),
+	});
 
 	t.is(spy.callCount, 0);
 	const cacheMePlease = name => name.slice(1).toUpperCase();


### PR DESCRIPTION
- For https://github.com/fregante/webext-storage-cache/issues/34

The internal memoizer should only cache in-flight calls, but it's currently memoizing functions forever. This means sequential calls to a `cache.function` will not read from the cache anymore.

Warning: This changes how functions are memoized internally, but it actually brings the behavior closer to the actual storage-based memoization.