### PR TITLE
Use `getKeys` where available

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^6.0.0",
-		"@types/chrome": "0.0.268",
+		"@types/chrome": "^0.0.287",
 		"@types/sinon-chrome": "^2.2.15",
 		"sinon-chrome": "^3.0.1",
 		"tsd": "^0.31.1",

--- a/source/legacy.test.js
+++ b/source/legacy.test.js
@@ -101,17 +101,28 @@ test('set() with value', async () => {
 
 describe.each([
 	'legacy',
-	'getKeys',
+	// 'getKeys',
 ])('%s', async method => {
 	// WARNING: THIS IS NOT WORKING. It probably needs to be implemented via plugins
 	// TODO: https://github.com/acvetkov/sinon-chrome#plugins
+	// https://github.com/acvetkov/sinon-chrome/issues/113
 	chrome.storage.local.getKeys = method === 'getKeys' ? sinon.stub(async () => {
 		const whole = await chrome.storage.local.get();
 		return Object.keys(whole);
 	}) : undefined;
 
 	test('clear() with empty storage', async () => {
+		// Early sanity check
+		if (method === 'getKeys') {
+			t.is(chrome.storage.local.getKeys.callCount, 0);
+		}
+
 		await cache.clear();
+
+		if (method === 'getKeys') {
+			t.is(chrome.storage.local.getKeys.callCount, 1);
+		}
+
 		t.is(chrome.storage.local.remove.callCount, 0);
 	});
 

--- a/source/legacy.ts
+++ b/source/legacy.ts
@@ -29,7 +29,7 @@ export async function _get<ScopedValue extends Value>(
 	remove: boolean,
 ): Promise<CachedValue<ScopedValue> | undefined> {
 	const internalKey = `cache:${key}`;
-	const storageData = await chromeP.storage.local.get(internalKey) as Cache<ScopedValue>;
+	const storageData: Cache<ScopedValue> = await chromeP.storage.local.get(internalKey);
 	const cachedItem = storageData[internalKey];
 
 	if (cachedItem === undefined) {
@@ -87,12 +87,18 @@ async function delete_(userKey: string): Promise<void> {
 async function deleteWithLogic(
 	logic?: (x: CachedValue<Value>) => boolean,
 ): Promise<void> {
-	const wholeCache = (await chromeP.storage.local.get()) as Record<string, any>;
-	const removableItems: string[] = [];
-	for (const [key, value] of Object.entries(wholeCache)) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: value is any
-		if (key.startsWith('cache:') && (logic?.(value) ?? true)) {
-			removableItems.push(key);
+	let removableItems: string[] = [];
+	// `getKeys`: https://github.com/w3c/webextensions/issues/601#issuecomment-2434544881
+	const allKeys = await chrome.storage.local.getKeys?.() ?? [];
+	const cacheKeys = allKeys.filter(key => key.startsWith('cache:'));
+	if (!logic && typeof chrome.storage.local.getKeys === 'function') {
+		removableItems = cacheKeys;
+	} else {
+		const wholeCache: Cache = await chromeP.storage.local.get(cacheKeys);
+		for (const [key, value] of Object.entries(wholeCache)) {
+			if (key.startsWith('cache:') && (logic?.(value) ?? true)) {
+				removableItems.push(key);
+			}
 		}
 	}
 


### PR DESCRIPTION
- Closes https://github.com/fregante/webext-storage-cache/issues/50

Advantages:

- when calling `cache.clear()`: the values are not loaded into memory
- when calling `deleteExpired`: only `cache:` values are loaded into memory, not unrelated values